### PR TITLE
remove warnings when using Elixir 1.18

### DIFF
--- a/lib/base62.ex
+++ b/lib/base62.ex
@@ -1,4 +1,4 @@
 defmodule Shortcode.Base62 do
   @moduledoc false
-  use CustomBase, '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  use CustomBase, ~c"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Shortcode.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elielhaouzi/shortcode"
-  @version "0.7.0"
+  @version "0.7.1"
 
   def project do
     [


### PR DESCRIPTION
Elixir 1.18 deprecated the old charlist syntax